### PR TITLE
Duedate headings

### DIFF
--- a/src/pages/Content/modules/components/radial-bar-chart/index.tsx
+++ b/src/pages/Content/modules/components/radial-bar-chart/index.tsx
@@ -111,7 +111,7 @@ export default function RadialBarChart({
             onClick={handleClick}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            progress={bar.value / bar.max}
+            progress={bar.max != 0 ? bar.value / bar.max : 1}
             radius={cutout + radius * (i + 1)}
             width={strokeWidth}
           />

--- a/src/pages/Content/modules/utils/getDaysLeft.test.ts
+++ b/src/pages/Content/modules/utils/getDaysLeft.test.ts
@@ -1,0 +1,144 @@
+import { Assignment } from '../types';
+import getDaysLeft from './getDaysLeft';
+import forEachTZ from '../tests/utils/forEachTZ';
+
+let dateNowSpy: jest.SpyInstance;
+
+afterAll(() => {
+  // Unlock Time
+  dateNowSpy.mockRestore();
+});
+
+test('Returns 0 on the same day', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2021, 1, 26, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(0);
+    a.due_at = new Date(2021, 1, 26, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(0);
+  });
+});
+
+test('Returns 1 for next day', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2021, 1, 27, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(1);
+    a.due_at = new Date(2021, 1, 27, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(1);
+  });
+});
+
+test('Returns 2 for day after tomorrow', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2021, 1, 28, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(2);
+    a.due_at = new Date(2021, 1, 28, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(2);
+  });
+});
+
+test('Returns correct days in different month', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2021, 2, 1, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(3);
+    a.due_at = new Date(2021, 2, 31, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(33);
+    a.due_at = new Date(2021, 3, 1, 0, 0, 0).toISOString();
+    expect(getDaysLeft(a)).toBe(34);
+  });
+});
+
+test('Returns correct days in different year', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2022, 0, 1, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(309);
+    a.due_at = new Date(2022, 11, 31, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(673);
+    a.due_at = new Date(2023, 11, 31, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(1038);
+  });
+});
+
+test('Returns negative days', () => {
+  forEachTZ(() => {
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => new Date(2021, 1, 26, 0, 0, 0).valueOf());
+    const a: Assignment = {
+      due_at: new Date(2021, 1, 25, 0, 0, 0).toISOString(),
+      html_url: '',
+      name: '',
+      points_possible: 0,
+      course_id: 1,
+      id: 1,
+      user_submitted: false,
+      is_quiz_assignment: false,
+    };
+    expect(getDaysLeft(a)).toBe(-1);
+    a.due_at = new Date(2021, 1, 25, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(-1);
+    a.due_at = new Date(2021, 0, 31, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(-26);
+    a.due_at = new Date(2020, 11, 31, 23, 59, 59).toISOString();
+    expect(getDaysLeft(a)).toBe(-57);
+  });
+});

--- a/src/pages/Content/modules/utils/getDaysLeft.ts
+++ b/src/pages/Content/modules/utils/getDaysLeft.ts
@@ -1,0 +1,9 @@
+import { Assignment } from '../types';
+
+export default function getDaysLeft(assignment: Assignment): number {
+  const due = new Date(assignment.due_at);
+  due.setHours(0, 0, 0);
+  const now = new Date(Date.now());
+  now.setHours(0, 0, 0);
+  return Math.round((due.getTime() - now.getTime()) / (1000 * 3600 * 24));
+}

--- a/src/pages/Content/modules/utils/getDueDateHeadingLabel.ts
+++ b/src/pages/Content/modules/utils/getDueDateHeadingLabel.ts
@@ -1,18 +1,19 @@
-const days = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-];
+// const days = [
+//   'Sunday',
+//   'Monday',
+//   'Tuesday',
+//   'Wednesday',
+//   'Thursday',
+//   'Friday',
+//   'Saturday',
+// ];
 
 export default function getDueDateHeadingLabel(delta: number): string {
   if (delta < 0) return 'Overdue';
   if (delta == 0) return 'Today';
   else if (delta == 1) return 'Tomorrow';
-  else if (delta < 7) return days[(new Date(Date.now()).getDay() + delta) % 7];
+  else if (delta < 7) return `${delta} days`;
+  // days[(new Date(Date.now()).getDay() + delta) % 7];
   else if (delta < 14) return '1 week';
   else return `${Math.floor(delta / 7)} weeks`;
 }

--- a/src/pages/Content/modules/utils/getDueDateHeadingLabel.ts
+++ b/src/pages/Content/modules/utils/getDueDateHeadingLabel.ts
@@ -1,0 +1,18 @@
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+export default function getDueDateHeadingLabel(delta: number): string {
+  if (delta < 0) return 'Overdue';
+  if (delta == 0) return 'Today';
+  else if (delta == 1) return 'Tomorrow';
+  else if (delta < 7) return days[(new Date(Date.now()).getDay() + delta) % 7];
+  else if (delta < 14) return '1 week';
+  else return `${Math.floor(delta / 7)} weeks`;
+}


### PR DESCRIPTION
Add headings to todo list for different due dates in order to chunk the assignments list down and make it easier to see what needs to be done and when. Closes #27 