### PR TITLE
Fix zip command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "node utils/build.js chrome",
     "firefox": "node utils/build.js firefox",
-    "zip": "zip -r build.zip build/* -x \"build/.*\" -x \"build/__MACOSX\"",
+    "zip": "cd build; zip -r ../build.zip * -x \"build/.*\" -x \"build/__MACOSX\"",
     "start": "node utils/webserver.js chrome",
     "prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,html}'",
     "lint": "eslint src/**/*.ts src/**/*.tsx",


### PR DESCRIPTION
The current zip command includes the enclosing folder instead of having the files in the root.