### PR TITLE
API pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "node utils/build.js chrome",
     "firefox": "node utils/build.js firefox",
     "zip": "cd build; zip -r ../build.zip * -x \"build/.*\" -x \"build/__MACOSX\"",
-    "start": "node utils/webserver.js chrome",
+    "start": "node utils/webserver.js",
     "prettier": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,html}'",
     "lint": "eslint src/**/*.ts src/**/*.tsx",
     "test": "jest",

--- a/src/pages/Content/modules/hooks/useAssignments.unit.test.ts
+++ b/src/pages/Content/modules/hooks/useAssignments.unit.test.ts
@@ -28,7 +28,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('getAllAssignment', () => {
   it('fetches assignments from the planner/items endpoint and fills in values', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes });
+    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes, headers: {} });
 
     const assignments = await getAllAssignments(
       new Date('2022-01-01'),
@@ -40,7 +40,7 @@ describe('getAllAssignment', () => {
     expect(assignments[0].marked_complete).toBe(false);
   });
   it('substitutes null/empty values with defaults', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes });
+    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes, headers: {} });
 
     const assignments = await getAllAssignments(
       new Date('2022-01-01'),
@@ -58,7 +58,7 @@ describe('getAllAssignment', () => {
     expect(assignments[0].color).toBe(AssignmentDefaults.color);
   });
   it('filters to assignment types', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes });
+    mockedAxios.get.mockResolvedValueOnce({ data: plannerRes, headers: {} });
 
     let assignments = await getAllAssignments(
       new Date('2022-01-01'),


### PR DESCRIPTION
Support more than 100 assignments and fix case where planner might return many other items (calendar events, announcements, etc.), resulting some assignments being missed (especially in month view). Closes #85 .