### PR TITLE
Show assignment grades in completed tab

### DIFF
--- a/src/pages/Content/modules/components/dynamic-settings/DynamicSettings.tsx
+++ b/src/pages/Content/modules/components/dynamic-settings/DynamicSettings.tsx
@@ -118,6 +118,11 @@ export default function DynamicSettings({ options }: Props): JSX.Element {
             onClick={updater('sidebar', true)}
             text="Hide existing To Do sidebar"
           />
+          <Checkbox
+            checked={optionsStore.state.due_date_headings}
+            onClick={updater('due_date_headings', false)}
+            text="Divide assignments by due date"
+          />
         </CheckboxSection>
         <InfoSection>
           <span>

--- a/src/pages/Content/modules/components/task-card/AnnouncementCard.tsx
+++ b/src/pages/Content/modules/components/task-card/AnnouncementCard.tsx
@@ -22,10 +22,7 @@ import {
 */
 
 export default function AnnouncementCard({
-  name = AssignmentDefaults.name,
-  type = AssignmentDefaults.type,
-  html_url = AssignmentDefaults.html_url,
-  due_at = AssignmentDefaults.due_at,
+  assignment = AssignmentDefaults,
   course_name,
   complete = AssignmentDefaults.marked_complete,
   color,
@@ -34,12 +31,12 @@ export default function AnnouncementCard({
   transitionState,
 }: TaskProps): JSX.Element {
   if (complete) color = color + '99';
-  const posted_ago = fmtDateSince(due_at);
+  const posted_ago = fmtDateSince(assignment.due_at);
   function onClick(e: React.MouseEvent<HTMLInputElement>) {
     e.preventDefault();
-    window.location.href = html_url;
+    window.location.href = assignment.html_url;
   }
-  const icon = ASSIGNMENT_ICON[type];
+  const icon = ASSIGNMENT_ICON[assignment.type];
 
   const dueText = `${posted_ago}`;
   function markAssignmentAsComplete() {
@@ -79,7 +76,11 @@ export default function AnnouncementCard({
             ''
           )}
         </TaskTop>
-        <TaskLink dark={darkMode} href={html_url} opacity={complete ? 0.5 : 1}>
+        <TaskLink
+          dark={darkMode}
+          href={assignment.html_url}
+          opacity={complete ? 0.5 : 1}
+        >
           {!skeleton ? name : <SkeletonTitle dark={darkMode} />}
         </TaskLink>
         <TaskDetailsText opacity={complete ? 0.5 : 1}>

--- a/src/pages/Content/modules/components/task-card/AnnouncementCard.tsx
+++ b/src/pages/Content/modules/components/task-card/AnnouncementCard.tsx
@@ -81,7 +81,7 @@ export default function AnnouncementCard({
           href={assignment.html_url}
           opacity={complete ? 0.5 : 1}
         >
-          {!skeleton ? name : <SkeletonTitle dark={darkMode} />}
+          {!skeleton ? assignment.name : <SkeletonTitle dark={darkMode} />}
         </TaskLink>
         <TaskDetailsText opacity={complete ? 0.5 : 1}>
           {skeleton ? <SkeletonInfo dark={darkMode} /> : dueText}

--- a/src/pages/Content/modules/components/task-card/stories/CompletedTask.stories.tsx
+++ b/src/pages/Content/modules/components/task-card/stories/CompletedTask.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import TaskCard from '../TaskCard';
-import { AssignmentType } from '../../../types';
+import { AssignmentType, FinalAssignment } from '../../../types';
 
 export default {
   title: 'Components/Task/Completed',
@@ -12,56 +12,73 @@ export default {
 } as ComponentMeta<typeof TaskCard>;
 
 const Template: ComponentStory<typeof TaskCard> = (args) => (
-  <TaskCard {...args} />
+  <TaskCard
+    {...args}
+    color="#ab3c7d"
+    complete
+    course_name="Course name"
+    skeleton={false}
+  />
 );
 
-const storyDefaults = {
+const storyDefaults: FinalAssignment = {
   name: 'Assignment name',
   type: AssignmentType.ASSIGNMENT,
   html_url: '/',
   due_at: '2022-01-01Z00:00:00',
-  course_name: 'Course name',
   points_possible: 10,
-  complete: true,
   graded: false,
   graded_at: '',
-  color: '#ab3c7d',
   submitted: true,
-  skeleton: false,
+  course_id: '0',
+  id: '1',
+  plannable_id: '1',
+  score: 0,
+  marked_complete: false,
 };
 
 // point not points
 export const OnePoint = Template.bind({});
 OnePoint.args = {
-  ...storyDefaults,
-  points_possible: 1,
+  assignment: {
+    ...storyDefaults,
+    points_possible: 1,
+  },
 };
 
 export const Points = Template.bind({});
 Points.args = {
-  ...storyDefaults,
-  points_possible: 10,
+  assignment: {
+    ...storyDefaults,
+    points_possible: 10,
+  },
 };
 
 export const GradedNoScore = Template.bind({});
 GradedNoScore.args = {
-  ...storyDefaults,
-  points_possible: 10,
-  graded: true,
-  graded_at: '2022-01-02Z00:00:00',
+  assignment: {
+    ...storyDefaults,
+    points_possible: 10,
+    graded: true,
+    graded_at: '2022-01-02Z00:00:00',
+  },
 };
 
 export const NoPoints = Template.bind({});
 NoPoints.args = {
-  ...storyDefaults,
-  points_possible: 0,
+  assignment: {
+    ...storyDefaults,
+    points_possible: 0,
+  },
 };
 
 export const Unsubmitted = Template.bind({});
 Unsubmitted.args = {
-  ...storyDefaults,
-  points_possible: 10,
-  graded: true,
-  submitted: false,
-  graded_at: '2022-01-02Z00:00:00',
+  assignment: {
+    ...storyDefaults,
+    points_possible: 10,
+    graded: true,
+    submitted: false,
+    graded_at: '2022-01-02Z00:00:00',
+  },
 };

--- a/src/pages/Content/modules/components/task-card/stories/UnfinishedTask.stories.tsx
+++ b/src/pages/Content/modules/components/task-card/stories/UnfinishedTask.stories.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import TaskCard from '../TaskCard';
-import { AssignmentType } from '../../../types';
-import { AssignmentDefaults } from '../../../constants';
+import { AssignmentType, FinalAssignment } from '../../../types';
 
 export default {
   title: 'Components/Task/Unfinished',
@@ -13,75 +12,96 @@ export default {
 } as ComponentMeta<typeof TaskCard>;
 
 const Template: ComponentStory<typeof TaskCard> = (args) => (
-  <TaskCard {...args} />
+  <TaskCard
+    {...args}
+    color="#ab3c7d"
+    complete={false}
+    course_name="Course name"
+  />
 );
 
-const storyDefaults = {
+const storyDefaults: FinalAssignment = {
   name: 'Assignment name',
   type: AssignmentType.ASSIGNMENT,
   html_url: '/',
   due_at: '2022-01-01Z00:00:00',
-  course_name: 'Course name',
   points_possible: 10,
-  complete: false,
   graded: false,
   graded_at: '',
-  color: '#ab3c7d',
   submitted: false,
-  skeleton: false,
   needs_grading_count: 0,
+  course_id: '0',
+  id: '1',
+  plannable_id: '1',
+  score: 0,
+  marked_complete: false,
 };
 
 export const Assignment = Template.bind({});
 Assignment.args = {
-  ...storyDefaults,
+  assignment: storyDefaults,
 };
 
 export const NeedsGrading = Template.bind({});
 NeedsGrading.args = {
-  ...storyDefaults,
-  needs_grading_count: 4,
+  assignment: {
+    ...storyDefaults,
+    needs_grading_count: 4,
+  },
 };
 
 export const Discussion = Template.bind({});
 Discussion.args = {
-  ...storyDefaults,
-  type: AssignmentType.DISCUSSION,
+  assignment: {
+    ...storyDefaults,
+    type: AssignmentType.DISCUSSION,
+  },
 };
 
 export const Quiz = Template.bind({});
 Quiz.args = {
-  ...storyDefaults,
-  type: AssignmentType.QUIZ,
+  assignment: {
+    ...storyDefaults,
+    type: AssignmentType.QUIZ,
+  },
 };
 
 export const Note = Template.bind({});
 Note.args = {
-  ...storyDefaults,
-  type: AssignmentType.NOTE,
+  assignment: {
+    ...storyDefaults,
+    type: AssignmentType.NOTE,
+  },
 };
 
 export const Skeleton = Template.bind({});
 Skeleton.args = {
-  html_url: '/',
+  assignment: {
+    ...storyDefaults,
+    html_url: '/',
+  },
   skeleton: true,
 };
 
 export const Default = Template.bind({});
 Default.args = {
-  ...AssignmentDefaults,
+  assignment: storyDefaults,
   skeleton: false,
 };
 
 // point not points
 export const OnePoint = Template.bind({});
 OnePoint.args = {
-  ...storyDefaults,
-  points_possible: 1,
+  assignment: {
+    ...storyDefaults,
+    points_possible: 1,
+  },
 };
 
 export const NoPoints = Template.bind({});
 NoPoints.args = {
-  ...storyDefaults,
-  points_possible: 0,
+  assignment: {
+    ...storyDefaults,
+    points_possible: 0,
+  },
 };

--- a/src/pages/Content/modules/components/task-container/TaskContainer.tsx
+++ b/src/pages/Content/modules/components/task-container/TaskContainer.tsx
@@ -70,7 +70,7 @@ function TaskContainer({
     setDelayLoad(false);
     let res = Object.values(assignmentStore.state);
     if (courseId) res = filterCourses([courseId], res);
-    return filterTimeBounds(startDate, endDate, res);
+    return filterTimeBounds(startDate, endDate, res, true);
   }, [assignmentStore.assignmentList, startDate, endDate, courseId]);
   const updatedAnnouncements = useMemo(() => {
     if (courseId)

--- a/src/pages/Content/modules/components/task-container/TaskContainer.tsx
+++ b/src/pages/Content/modules/components/task-container/TaskContainer.tsx
@@ -71,7 +71,7 @@ function TaskContainer({
     let res = Object.values(assignmentStore.state);
     if (courseId) res = filterCourses([courseId], res);
     return filterTimeBounds(startDate, endDate, res, true);
-  }, [assignmentStore.assignmentList, startDate, endDate, courseId]);
+  }, [assignmentStore.assignmentList, courseId]);
   const updatedAnnouncements = useMemo(() => {
     if (courseId)
       return filterCourses([courseId], Object.values(announcementStore.state));

--- a/src/pages/Content/modules/components/task-list/TaskList.tsx
+++ b/src/pages/Content/modules/components/task-list/TaskList.tsx
@@ -257,13 +257,10 @@ export default function TaskList({
   ) => {
     return tab !== 'Announcements' ? (
       <TaskCard
+        assignment={assignment}
         color={courseStore.state[assignment.course_id].color}
         complete={assignmentIsDone(assignment)}
         course_name={courseStore.state[assignment.course_id].name}
-        due_at={assignment.due_at}
-        graded={assignment.graded}
-        graded_at={assignment.graded_at}
-        html_url={assignment.html_url}
         key={key}
         markComplete={markAssignmentFunc(
           assignment.id,
@@ -277,20 +274,14 @@ export default function TaskList({
           AssignmentStatus.DELETED,
           markAssignment
         )}
-        name={assignment.name}
-        needs_grading_count={assignment.needs_grading_count}
-        points_possible={assignment.points_possible}
-        submitted={assignment.submitted}
         transitionState={state}
-        type={assignment.type}
       />
     ) : (
       <AnnouncementCard
+        assignment={assignment}
         color={courseStore.state[assignment.course_id].color}
         complete={assignmentIsDone(assignment)}
         course_name={courseStore.state[assignment.course_id].name}
-        due_at={assignment.due_at}
-        html_url={assignment.html_url}
         key={key}
         markComplete={markAssignmentFunc(
           assignment.id,
@@ -298,9 +289,7 @@ export default function TaskList({
           AssignmentStatus.SEEN,
           markAssignment
         )}
-        name={assignment.name}
         transitionState={state}
-        type={assignment.type}
       />
     );
   };

--- a/src/pages/Content/modules/components/task-list/utils/groupByHeadings.ts
+++ b/src/pages/Content/modules/components/task-list/utils/groupByHeadings.ts
@@ -1,4 +1,5 @@
 import { FinalAssignment } from '../../../types';
+import assignmentHasGrade from '../../../utils/assignmentHasGrade';
 import getDaysLeft from './getDaysLeft';
 import { TaskTypeTab } from './useHeadings';
 
@@ -36,14 +37,14 @@ export function groupByStatusHeadings(
   currentTab: TaskTypeTab = 'Completed'
 ): Record<string, FinalAssignment[]> {
   const headings: Record<string, FinalAssignment[]> = {
-    Ungraded: [],
     Graded: [],
+    Ungraded: [],
     Unread: [],
     Seen: [],
   };
   if (currentTab === 'Completed') {
     assignments.forEach((a) => {
-      if (a.graded) headings['Graded'].push(a);
+      if (assignmentHasGrade(a)) headings['Graded'].push(a);
       else headings['Ungraded'].push(a);
     });
   } else if (currentTab === 'Announcements') {

--- a/src/pages/Content/modules/components/task-list/utils/sortBy.ts
+++ b/src/pages/Content/modules/components/task-list/utils/sortBy.ts
@@ -1,4 +1,5 @@
 import { FinalAssignment } from '../../../types';
+import assignmentHasGrade from '../../../utils/assignmentHasGrade';
 import assignmentIsDone from '../../../utils/assignmentIsDone';
 import { TaskTypeTab } from './useHeadings';
 
@@ -11,24 +12,27 @@ export function sortByGraded(
   assignments: FinalAssignment[]
 ): FinalAssignment[] {
   return assignments.sort((a, b) => {
-    if (a.graded == b.graded) return compareISODates(b.due_at, a.due_at);
-    return (a.graded ? 1 : -1) - (b.graded ? 1 : -1);
+    const ag = assignmentHasGrade(a);
+    const bg = assignmentHasGrade(b);
+    if (ag === bg) return compareISODates(b.due_at, a.due_at); // new before old
+    return (ag ? -1 : 1) - (bg ? -1 : 1); // graded before ungraded
   });
 }
 
 export function sortByRead(assignments: FinalAssignment[]): FinalAssignment[] {
   return assignments.sort((a, b) => {
     if (a.marked_complete == b.marked_complete)
-      return compareISODates(b.due_at, a.due_at);
-    return (a.marked_complete ? 1 : -1) - (b.marked_complete ? 1 : -1);
+      return compareISODates(b.due_at, a.due_at); // new before old
+    return (a.marked_complete ? 1 : -1) - (b.marked_complete ? 1 : -1); // incomplete before complete
   });
 }
 
 export function sortByDate(assignments: FinalAssignment[]): FinalAssignment[] {
   return assignments.sort((a, b) => {
+    // needs grading before not needs grading
     if (a.needs_grading_count && !b.needs_grading_count) return 1;
     else if (!a.needs_grading_count && b.needs_grading_count) return -1;
-    return compareISODates(a.due_at, b.due_at);
+    return compareISODates(a.due_at, b.due_at); // old before new
   });
 }
 

--- a/src/pages/Content/modules/hooks/useAssignmentStore.ts
+++ b/src/pages/Content/modules/hooks/useAssignmentStore.ts
@@ -67,7 +67,6 @@ export function useNewAssignmentStore(
     assignments.forEach((assignment) => (temp[assignment.id] = assignment));
     initialize(temp);
     setAssignmentList(Object.keys(temp));
-    console.log(temp);
   }
 
   return {

--- a/src/pages/Content/modules/hooks/useAssignmentStore.ts
+++ b/src/pages/Content/modules/hooks/useAssignmentStore.ts
@@ -67,6 +67,7 @@ export function useNewAssignmentStore(
     assignments.forEach((assignment) => (temp[assignment.id] = assignment));
     initialize(temp);
     setAssignmentList(Object.keys(temp));
+    console.log(temp);
   }
 
   return {

--- a/src/pages/Content/modules/hooks/useAssignments.ts
+++ b/src/pages/Content/modules/hooks/useAssignments.ts
@@ -153,9 +153,11 @@ export function convertPlannerAssignments(
 export function filterTimeBounds(
   startDate: Date,
   endDate: Date,
-  assignments: FinalAssignment[]
+  assignments: FinalAssignment[],
+  excludeNeedsGrading?: boolean
 ): FinalAssignment[] {
   return assignments.filter((assignment) => {
+    if (excludeNeedsGrading && assignment.needs_grading_count) return true;
     const due_date = new Date(assignment.due_at);
     return (
       due_date.valueOf() >= startDate.valueOf() &&

--- a/src/pages/Content/modules/hooks/useOptions.ts
+++ b/src/pages/Content/modules/hooks/useOptions.ts
@@ -46,14 +46,20 @@ export function useOptionsStore(
   }
   useEffect(() => {
     // add observers here
-    chrome.storage.onChanged.addListener((changes) => {
+    const storageListener = (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => {
       for (const [key, { oldValue, newValue }] of Object.entries(changes)) {
         if (storedUserOptions.includes(key) && oldValue !== newValue) {
           update([key], newValue, false);
           if (onUpdateCallback) onUpdateCallback();
         }
       }
-    });
+    };
+    chrome.storage.onChanged.addListener(storageListener);
+    return () => {
+      chrome.storage.onChanged.removeListener(storageListener);
+    };
   }, []);
 
   return { state, update: updateKey };

--- a/src/pages/Content/modules/hooks/utils/gqlReq.ts
+++ b/src/pages/Content/modules/hooks/utils/gqlReq.ts
@@ -1,0 +1,22 @@
+import apiReq from '../../utils/apiReq';
+
+/* From my understanding, graphql never paginates unless client explicitly specifies it */
+export default async function graphqlReq<Type>(
+  queries: string[]
+): Promise<Type> {
+  if (queries.length === 0) return {} as Type;
+  const data = {
+    query: `query MyQuery {
+          ${queries.reduce((prev, curr) => prev + '\n' + curr, '')}
+        }`,
+  };
+  try {
+    const resp = await apiReq('/graphql', JSON.stringify(data), 'post');
+    if ('errors' in resp.data || resp.status / 100 != 2) return {} as Type;
+    const res = resp.data.data as Type;
+    return res;
+  } catch (err) {
+    console.error(err);
+    return {} as Type;
+  }
+}

--- a/src/pages/Content/modules/hooks/utils/loadGraded.ts
+++ b/src/pages/Content/modules/hooks/utils/loadGraded.ts
@@ -1,0 +1,68 @@
+import graphqlReq from './gqlReq';
+
+interface GQLResponse {
+  [key: string]: {
+    submissionsConnection: {
+      nodes: {
+        gradingStatus: string;
+        score: number | null;
+        grade: string | null;
+      }[];
+    };
+  };
+}
+
+export interface GradeStatus {
+  score: number;
+  grade: string;
+}
+
+/*
+Check how many of the assignments have a >0 grade
+- assignments that (do NOT have a >0 grade) and (are NEITHER submitted nor marked complete) are incomplete
+- ideally this is only querying graded assignments, which should not take long
+*/
+export async function queryGraded(
+  ids: string[]
+): Promise<Record<string, GradeStatus>> {
+  const newQuery = (
+    id: string,
+    idx: number
+  ) => `  item${idx}: assignment(id: ${id}) {
+      submissionsConnection {
+        nodes {
+          gradingStatus
+          grade
+          score
+        }
+      }
+    }`;
+
+  const queries = ids.map((id, idx) => newQuery(id, idx));
+
+  try {
+    const counts = await graphqlReq<GQLResponse>(queries);
+
+    const keys = Object.keys(counts);
+
+    const ret: Record<string, GradeStatus> = {};
+    ids.forEach((id, idx) => {
+      // will be null if id is invalid
+      if (
+        counts[keys[idx]] &&
+        counts[keys[idx]].submissionsConnection?.nodes.length
+      ) {
+        const res = counts[keys[idx]].submissionsConnection?.nodes[0];
+        ret[id] = {
+          score: res.score ? res.score : 0,
+          grade: res.grade ? res.grade : '',
+        };
+        if (res.gradingStatus === 'excused') ret[id].grade = 'Excused';
+      }
+    });
+    return ret;
+  } catch (err) {
+    console.error(err);
+    return {};
+  }
+}

--- a/src/pages/Content/modules/types/assignment.ts
+++ b/src/pages/Content/modules/types/assignment.ts
@@ -24,6 +24,7 @@ interface PlannerAssignment {
       }
     | false;
   plannable: {
+    assignment_id?: string; // use this for graphql requests
     id: string;
     title: string;
     details?: string;
@@ -69,6 +70,7 @@ interface FinalAssignment {
   graded: boolean; // has the teacher graded it?
   graded_at: string; // date the teacher graded (if graded)
   score: number; // grade assigned, 0 if ungraded or unsubmitted
+  grade?: string; // grade displayed (letter scale or point scale)
   type: AssignmentType;
   // course_name: string; // via useCourseName
   marked_complete: boolean; // marked complete in the sidebar or through the planner

--- a/src/pages/Content/modules/utils/assignmentHasGrade.ts
+++ b/src/pages/Content/modules/utils/assignmentHasGrade.ts
@@ -1,0 +1,9 @@
+import { FinalAssignment } from '../types';
+
+// whether the assignment has a grade (inputted by instructor) to display
+// this is unique from the "graded" field, which just tells whether it should appear in the "completed" tab
+export default function assignmentHasGrade(
+  assignment: FinalAssignment
+): boolean {
+  return assignment.graded || !!assignment.grade || !!assignment.graded_at;
+}


### PR DESCRIPTION
This was an old feature that had to be dropped when switching to the planner API. Bringing it back now through a separate graphql request to retrieve the grades. The `graded_at` property makes the graphql queries efficient since we already know which assignments have a grade.