### PR TITLE
Added option for Three days

### DIFF
--- a/src/pages/Content/modules/types/options.ts
+++ b/src/pages/Content/modules/types/options.ts
@@ -1,4 +1,4 @@
-export type Period = 'Day' | 'Week' | 'Month';
+export type Period = 'Day' | 'ThreeDay' | 'Week' | 'Month';
 
 type Options = {
   color_tabs: boolean;

--- a/src/pages/Content/modules/utils/getPeriod.ts
+++ b/src/pages/Content/modules/utils/getPeriod.ts
@@ -15,6 +15,18 @@ export function getDayEnd(startDate: Date): Date {
   return d;
 }
 
+export function getThreeDayStart(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0);
+  return d;
+}
+export function getThreeDayEnd(startDate: Date): Date {
+  const d = new Date(startDate);
+  d.setDate(d.getDate() + 3);
+  d.setHours(0, 0, 0);
+  return d;
+}
+
 /*
   functions to get the previous and next occurence of a specific day of the week
 */
@@ -74,6 +86,9 @@ export default function getPeriod(
     switch (period) {
       case 'Month':
         break;
+      case 'ThreeDay':
+        prevPeriodStart = getThreeDayStart();
+        break;
       case 'Day':
         prevPeriodStart = getDayStart();
         break;
@@ -90,6 +105,11 @@ export default function getPeriod(
     case 'Month':
       prevPeriodStart.setMonth(prevPeriodStart.getMonth() + delta);
       nextPeriodStart.setMonth(nextPeriodStart.getMonth() + delta);
+      break;
+    case 'ThreeDay':
+      nextPeriodStart = getThreeDayEnd(prevPeriodStart);
+      prevPeriodStart.setDate(prevPeriodStart.getDate() + delta);
+      nextPeriodStart.setDate(nextPeriodStart.getDate() + delta);
       break;
     case 'Day':
       nextPeriodStart = getDayEnd(prevPeriodStart);

--- a/src/pages/Options/index.html
+++ b/src/pages/Options/index.html
@@ -21,6 +21,7 @@
       <div id="content">
         <div id="period-selector">
           <div id="day" class="period-option">Day</div>
+          <div id="three_day" class="period-option">Three Days</div>
           <div id="week" class="period-option selected-period">Week</div>
           <div id="month" class="period-option">Month</div>
         </div>

--- a/src/pages/Options/index.ts
+++ b/src/pages/Options/index.ts
@@ -151,6 +151,7 @@ function getSelectedAmPm() {
 
 const periods: Record<string, string> = {
   day: 'Day',
+  three_day: 'ThreeDay',
   week: 'Week',
   month: 'Month',
 };


### PR DESCRIPTION
Instead of just showing one day or showing the whole week you will only see the next three days.

Issue #145 